### PR TITLE
feature/sonos-coordinator

### DIFF
--- a/soreco-firmware.ino
+++ b/soreco-firmware.ino
@@ -45,4 +45,5 @@ void loop() {
     debugConsole.loop();
     wifiManager.loop(); // TODO move to state machine
     deviceStateMachine.runStateMachine();
+    delay(10);
 }

--- a/src/DebugConsole/DebugConsole.cpp
+++ b/src/DebugConsole/DebugConsole.cpp
@@ -191,15 +191,15 @@ void cmdSonosDiscover(void) {
 
     for (std::size_t i = 0; i < sonosDevices.size(); i++) {
         IPAddress ip = sonosDevices[i].getIp();
-        // cache the device description and zone info to reduce network traffic
-        const std::string xmlDeviceDescription = SonosCommandBuilder::getDeviceDescription(ip);
+        const std::string uuid = sonosDevices[i].getUUID();
+        const std::string roomName = sonosDevices[i].getRoomName();
+        // cache the zone info to reduce network traffic
         const SonosZoneInfo zoneInfo = sonosDevices[i].getZoneGroupState();
-        const std::string roomName = sonosDevices[i].getRoomName(xmlDeviceDescription);
         const bool isJoined = sonosDevices[i].isJoined(zoneInfo);
-        const bool isCoordinator = sonosDevices[i].isCoordinator(xmlDeviceDescription, zoneInfo);
+        const bool isCoordinator = sonosDevices[i].isCoordinator(zoneInfo);
 
         Serial.print(i + 1); Serial.print(F(": ")); Serial.print(roomName.c_str());
-        Serial.print(F(" (")); Serial.print(ip);
+        Serial.print(F(" (")); Serial.print(ip); Serial.print(F(", ")); Serial.print(uuid.c_str());
         if (isJoined) {
             Serial.print(F(", joined"));
         }

--- a/src/DeviceState/DeviceHandler.cpp
+++ b/src/DeviceState/DeviceHandler.cpp
@@ -35,11 +35,11 @@ void DeviceHandler::connectToSonos(const DeviceSettings::SonosConfig& sonosConfi
     const uint16_t SONOS_DISCOVER_TIMEOUT_MS = 1000;
     SonosDevice coordinator = SonosDiscovery::discoverCoordinator(SONOS_DISCOVER_TIMEOUT_MS, roomName);
     if (coordinator.isIpValid()) {
-        Serial.print("Found Sonos coordinator = "); Serial.println(m_sonosCoordinator.getIp());
+        Serial.print("Found Sonos coordinator = "); Serial.println(coordinator.getIp());
         setSonosCoordinator(coordinator);
     }
     else {
-        Serial.print(F("Warning - unable to connect to Sonos room")); Serial.println(roomName.c_str());
+        Serial.print(F("Warning - unable to connect to Sonos room ")); Serial.println(roomName.c_str());
     }
 }
 

--- a/src/DeviceState/DeviceHandler.cpp
+++ b/src/DeviceState/DeviceHandler.cpp
@@ -30,12 +30,12 @@ void DeviceHandler::connectToSonos(const DeviceSettings::SonosConfig& sonosConfi
         Serial.println(F("Warning - no Sonos room configured"));
         return;
     }
-    Serial.print(F("Connecting to Sonos room ")); Serial.println(roomName.c_str());
 
+    Serial.print(F("Connecting to Sonos room ")); Serial.println(roomName.c_str());
     const uint16_t SONOS_DISCOVER_TIMEOUT_MS = 1000;
     SonosDevice coordinator = SonosDiscovery::discoverCoordinator(SONOS_DISCOVER_TIMEOUT_MS, roomName);
     if (coordinator.isIpValid()) {
-        Serial.print("Found Sonos coordinator = "); Serial.println(coordinator.getIp());
+        Serial.print("..found Sonos coordinator with IP "); Serial.println(coordinator.getIp());
         setSonosCoordinator(coordinator);
     }
     else {

--- a/src/DeviceState/DeviceStateMachine.cpp
+++ b/src/DeviceState/DeviceStateMachine.cpp
@@ -46,7 +46,9 @@ void DeviceStateMachine::runStateMachine(void) {
                 conditionalStep(!m_deviceHandler.isSonosConnected(), State::Sonos_Retry);
                 break;
             case State::Sonos_Retry:
-                m_nextState = State::Sonos_Connecting;
+                conditionalStep(m_deviceHandler.isWifiConnected(), State::Sonos_Connecting);
+                // it could happen that WiFi connection is lost while searching for Sonos speaker
+                conditionalStep(!m_deviceHandler.isWifiConnected(), State::Wifi_Connecting);
                 break;
             case State::Idle:
                 // TODO

--- a/src/Sonos/SonosDevice.h
+++ b/src/Sonos/SonosDevice.h
@@ -53,12 +53,18 @@ public:
     SonosDevice(void);
 
     /**
-     * Constructor with IP address.
+     * Constructor with IP address and unique id.
      */
-    explicit SonosDevice(const IPAddress& ip);
+    explicit SonosDevice(const IPAddress& ip, const std::string& uuid);
+
+    /**
+     * Returns true if the device IP address is valid - false otherwise
+     */
+    bool isIpValid(void);
 
     /**
      * Update destination to the given IP address.
+     * Note: this method will attempt to get the UUID from the device.
      */
     void setIp(const IPAddress& ip);
 
@@ -66,6 +72,12 @@ public:
      * Get the IP address of the sonos device.
      */
     IPAddress getIp(void) const;
+
+    /**
+     * Get the UUID of the sonos device.
+     * Note: if no valid UUID is present, it will attempt to get it from the device.
+     */
+    std::string getUUID(void);
 
     /**
      * Get the play state of the device.
@@ -160,21 +172,24 @@ public:
      * Note: If a speaker is joined with other speakers in the zone, only the group coordinator can perform actions
      * @return True if the speaker is a group coordinator, otherwise False.
      */
-    bool isCoordinator(void) const;
+    bool isCoordinator(void);
 
     /**
      * Check if the speaker is a group coordinator or not.
      * Note: If a speaker is joined with other speakers in the zone, only the group coordinator can perform actions
-     * @param xmlDeviceDescription as XML string (from SonosCommandBuilder::getDeviceDescription() to reduce network traffic)
      * @param sonosZoneInfo (from getZoneGroupState() to reduce network traffic)
      * @return True if the speaker is a group coordinator, otherwise False.
      */
-    static bool isCoordinator(const std::string& xmlDeviceDescription, const SonosZoneInfo& sonosZoneInfo);
+    bool isCoordinator(const SonosZoneInfo& sonosZoneInfo);
 
 private:
 
+    bool isUUIDValid(void);
+    void updateUUID(void);
+
     // instance fields
     IPAddress m_ip;
+    std::string m_uuid;
 };
 
 #endif // SONOSDEVICE_H

--- a/src/Sonos/SonosDiscovery.h
+++ b/src/Sonos/SonosDiscovery.h
@@ -29,13 +29,25 @@ public:
      */
     static SonosDevice discoverByUID(const uint16_t timeoutMs, const std::string& uid);
 
+    /**
+     * Discover the Sonos speaker which is the coordinator using SSDP (Simple Service Discovery Protocol).
+     * a) is at least a device with the given room name joined?
+     *    --> if yes, find the coordinator of that group
+     * b) there could be multiple speaker in the same room (e.g. stereo pair)
+     *    --> if yes, find the coordinator of that room
+     * @param timeOutMs discovery timeout in milliseconds
+     * @param roomName name of the room to discover the coordinator
+     */
+    static SonosDevice discoverCoordinator(const uint16_t timeoutMs, const std::string& roomName);
+
 private:
 
     // SSDP port (Simple Service Discovery Protocol)
     static const uint16_t SSDP_PORT = 1900;
 
     // private helpers
-    static void processResponse(WiFiUDP& udpClient, std::vector<SonosDevice>& deviceList);
+    static void broadcastSearch(WiFiUDP& udpClient, const std::string& serviceType);
+    static bool processResponse(WiFiUDP& udpClient, std::vector<SonosDevice>& deviceList);
 
     /**
      * Private default constructor.

--- a/src/Sonos/SonosZoneInfo.cpp
+++ b/src/Sonos/SonosZoneInfo.cpp
@@ -25,7 +25,9 @@ std::vector<SonosDevice> SonosZoneInfo::getSonosDevicesInGroup(void) const {
     std::vector<SonosDevice> devices;
     for (std::string uid : m_zonePlayerUIDInGroup) {
         SonosDevice device = SonosDiscovery::discoverByUID(1000, uid);
-        devices.push_back(device);
+        if (device.isIpValid()) {
+            devices.push_back(device);
+        }
     }
     return devices;
 }


### PR DESCRIPTION
Created helper to find the coordinator for a given Sonos room name.
* added UUID as member to SonosDevice
* added discoverCoordinator to SonosDiscovery
* simplified DeviceHandler to use SonosDiscovery to find the coordinator
* fixed wrong IP console log of Sonos coordinator
* added condition to reconnect WiFi while looking for Sonos
* added delay in super loop to allow modem sleep