### PR TITLE
feature/esp8266-2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
 install:
   # Arduino
   - ln -s $PWD /usr/local/share/arduino/libraries/
-  - arduino --pref "boardsmanager.additional.urls=https://github.com/esp8266/Arduino/releases/download/2.4.0-rc2/package_esp8266com_index.json" --save-prefs
+  - arduino --pref "boardsmanager.additional.urls=https://github.com/esp8266/Arduino/releases/download/2.4.0/package_esp8266com_index.json" --save-prefs
   - arduino --install-boards esp8266:esp8266
   - arduino --board $BD --save-prefs
   - arduino --pref "compiler.warning_level=all" --save-prefs


### PR DESCRIPTION
Upgrade ESP8266 board package to latest version.
https://github.com/esp8266/Arduino/releases/tag/2.4.0