### PR TITLE
feature/sonos-play

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Open soreco-firmware.ino in Arduino and flash the NodeMCU 1.0 (or any other ESP-
 
 Interact with the device through the debug console with 115'200bps.
 
-Note: Requires ESP8266 board package version 2.4.0-rc2.
+Note: Requires ESP8266 at least board package version 2.4.0-rc2.
 https://github.com/esp8266/Arduino#installing-with-boards-manager
 
 ### Initializing Submodules
@@ -43,6 +43,7 @@ The debug console is currently the only way to interact with the device. There a
 * Sonos.Discover (scan and report all available Sonos devices)
 * Sonos.Connect (set Sonos device to control from debug console)
 * Sonos.PlayState (get / set the play state ('play' | 'pause') of the Sonos device)
+* Sonos.Volume (get / set the volume of the Sonos device)
 * Power.Mode (set the power mode ('modem' | 'light' | 'off') of ESP8266)
 
 ## System behavior

--- a/src/DebugConsole/DebugConsole.cpp
+++ b/src/DebugConsole/DebugConsole.cpp
@@ -10,9 +10,6 @@ extern "C" {
     #include "user_interface.h"
 }
 
-// Note: try to use flash strings to reduce RAM usage!
-// https://espressif.com/sites/default/files/documentation/save_esp8266ex_ram_with_progmem_en.pdf
-
 SerialCommands serialCommands;
 // workaround to have access from non-member functions to components
 WifiManager* pWiFiManager = NULL;
@@ -246,6 +243,26 @@ void cmdSonosPlayState(void) {
     }
 }
 
+void cmdSonosVolume(void) {
+    const char* argument = serialCommands.getArgument();
+    if (argument == NULL) {
+        // get
+        Serial.print(F("Sonos volume = ")); Serial.println(pSonosDevice->getVolume());
+    }
+    else {
+        // set
+        int volume = constrain(atoi(argument), 0, 100);
+        pSonosDevice->setVolume(volume);
+    }
+}
+
+void cmdSonosPlayUri(void) {
+    const char* argument = serialCommands.getArgument();
+    if (argument != NULL) {
+        pSonosDevice->playUri(argument, "");
+    }
+}
+
 // See https://www.espressif.com/sites/default/files/9b-esp8266-low_power_solutions_en_0.pdf for more information.
 // For testing purpose
 void cmdPowerMode(void) {
@@ -285,19 +302,6 @@ void cmdPowerMode(void) {
     }
 }
 
-void cmdSonosVolume(void) {
-    const char* argument = serialCommands.getArgument();
-    if (argument == NULL) {
-        // get
-        Serial.print(F("Sonos volume = ")); Serial.println(pSonosDevice->getVolume());
-    }
-    else {
-        // set
-        int volume = atoi(argument);
-        pSonosDevice->setVolume(volume);
-    }
-}
-
 DebugConsole::DebugConsole(void) {
 }
 
@@ -325,6 +329,7 @@ void DebugConsole::setup(WifiManager& wifiManager, SonosDevice& sonosDevice) {
     serialCommands.addCommand("Sonos.Connect", cmdSonosConnect);
     serialCommands.addCommand("Sonos.PlayState", cmdSonosPlayState);
     serialCommands.addCommand("Sonos.Volume", cmdSonosVolume);
+    serialCommands.addCommand("Sonos.PlayUri", cmdSonosPlayUri);
     serialCommands.addCommand("Power.Mode", cmdPowerMode);
 }
 

--- a/src/DebugConsole/SerialCommands.h
+++ b/src/DebugConsole/SerialCommands.h
@@ -59,7 +59,7 @@ private:
 
     void clearBuffer(void);
 
-    static const uint8_t MAX_COMMAND_LENGTH = 48;
+    static const uint8_t MAX_COMMAND_LENGTH = 128;
     static const uint8_t MAX_COMMANDS = 32;
     const char* COMMAND_DELIMITER = " ";
     const char COMMAND_TERMINATOR = '\n';


### PR DESCRIPTION
Directly play the given URI on the Sonos system. Example command:
Sonos.PlayUri x-rincon-mp3radio://www.radioswisspop.ch/live/aacp.m3u